### PR TITLE
Change uuid prop to key to work with Notistack 0.9.7

### DIFF
--- a/packages/manager/src/components/SnackBar/CloseSnackbar.tsx
+++ b/packages/manager/src/components/SnackBar/CloseSnackbar.tsx
@@ -12,7 +12,7 @@ import IconButton from 'src/components/IconButton';
 type ClassNames = 'icon';
 
 interface Props {
-  uuid: string;
+  key: string;
   text: string;
 }
 
@@ -31,7 +31,7 @@ const CloseSnackbar: React.FC<CombinedProps> = props => {
   const { closeSnackbar } = useSnackbar();
 
   const handleClose = () => {
-    closeSnackbar(props.uuid);
+    closeSnackbar(props.key);
   };
 
   return (

--- a/packages/manager/src/components/SnackBar/SnackBar.tsx
+++ b/packages/manager/src/components/SnackBar/SnackBar.tsx
@@ -48,7 +48,7 @@ class SnackBar extends React.Component<CombinedProps> {
           variantWarning: classes.warning,
           variantInfo: classes.info
         }}
-        action={<CloseSnackbar uuid={v4()} text="Dismiss Notification" />}
+        action={<CloseSnackbar key={v4()} text="Dismiss Notification" />}
       >
         {children}
       </SnackbarProvider>


### PR DESCRIPTION
## Description
Updates a prop name so that our dismissible notice logic works with the new version